### PR TITLE
output from subprocess call needs to be captured because it can be misleading

### DIFF
--- a/geeadd/geeadd.py
+++ b/geeadd/geeadd.py
@@ -214,9 +214,11 @@ def cancel_tasks(tasks):
 def delete(ids):
     try:
         print("Recursively deleting path: {}".format(ids))
-        subprocess.call(
-            "earthengine rm -r {}".format(ids), shell=True, stdout=subprocess.PIPE
-        )
+        # subprocess.call(
+        #     "earthengine rm -r {}".format(ids), shell=True, stdout=subprocess.PIPE
+        # )
+        process_output = subprocess.run(["earthengine", "rm", "-r", "{}".format(ids)], capture_output=True, text=True)
+        print("output from commandline: {}".format(process_output.stdout))
     except Exception as e:
         print(e)
 


### PR DESCRIPTION
The output from subprocess call needs to be captured and presented to the user because sometimes it can be misleading. For example in the following case, the user doesn't have access to the existing asset and w/o getting the subprocess output call, it may give the impression that the operation ran successfully (as shown in the first picture) but in fact, it wasn't (as shown in the second picture).

I tried this for `delete` command but similar use case may exist for other command. If you think this would a proper way to do it, I can help with tracking other command as well.

<img alt="image" src="https://github.com/samapriya/gee_asset_manager_addon/assets/4207677/2ca78ef7-f0d3-450e-bbc4-3147a2dc68df">

<img alt="image" src="https://github.com/samapriya/gee_asset_manager_addon/assets/4207677/9fa67a90-dc41-4077-af5b-ccf3127fe1c6">
